### PR TITLE
Bash complete hierarchicial cli

### DIFF
--- a/click/_bashcomplete.py
+++ b/click/_bashcomplete.py
@@ -30,18 +30,21 @@ def get_completion_script(prog_name, complete_var):
 
 def resolve_ctx(cli, prog_name, args):
     ctx = cli.make_context(prog_name, args, resilient_parsing=True)
-    while ctx.args and isinstance(ctx.command, MultiCommand):
-        cmd = ctx.command.get_command(ctx, ctx.args[0])
+    args = ctx.protected_args + ctx.args
+    while args and isinstance(ctx.command, MultiCommand):
+        cmd = ctx.command.get_command(ctx, args[0])
         if cmd is None:
             return None
-        ctx = cmd.make_context(ctx.args[0], ctx.args[1:], parent=ctx,
+        ctx = cmd.make_context(args[0], args[1:], parent=ctx,
                                resilient_parsing=True)
+        args = ctx.protected_args + ctx.args
     return ctx
 
 
 def do_complete(cli, prog_name):
     cwords = split_arg_string(os.environ['COMP_WORDS'])
     cword = int(os.environ['COMP_CWORD'])
+    
     args = cwords[1:cword]
     try:
         incomplete = cwords[cword]

--- a/tests/test_hcli_bashcomplete.py
+++ b/tests/test_hcli_bashcomplete.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+import click
+
+@click.group()
+def cli():
+    return
+
+@cli.group()
+def g1():
+    return
+
+@cli.group()
+def g2():
+    return
+
+@g1.command()
+def subcmd1():
+    return
+
+@g1.command()
+def subcmd2():
+    return
+
+
+@g2.command()
+def subcmd3():
+    return
+
+@g2.command()
+def subcmd4():
+    return
+
+
+def test():
+    from click._bashcomplete import resolve_ctx
+    ctx = resolve_ctx(cli, "hcli", ["g1"])
+    assert ctx.command.name == "g1"
+
+    ctx = resolve_ctx(cli, "hcli", ["g2", "subcmd3"])
+    assert ctx.command.name == "subcmd3"
+    return
+
+
+if __name__ == '__main__': test()


### PR DESCRIPTION
If the cli has a hierarchy of groups and commands, the bash complete did not work correctly. For example, the following cli

``` python
import click

@click.group()
def cli():
    return

@cli.group()
def g1():
    return

@cli.group()
def g2():
    return

@g1.command()
def subcmd1():
    return

@g1.command()
def subcmd2():
    return

@g2.command()
def subcmd3():
    return

@g2.command()
def subcmd4():
    return

cli()
```

when trying tab complete

``` bash
$ hcli g1
```

it will display choices "g1" and "g2" instead of the subcommands of "g1": "subcmd1" and "subcmd2".

This is an attempt to fix this issue.
